### PR TITLE
check if translation override is realy null

### DIFF
--- a/Classes/Domain/Translation.php
+++ b/Classes/Domain/Translation.php
@@ -31,7 +31,7 @@ class Translation
         ?string $fallbackLocaleIdentifier = null
     ) {
         $this->translation = empty($translation) ? null : $translation;
-        $this->override =  empty($override) ? null : $override;
+        $this->override =  $override;
         $this->fallback =  empty($fallback) ? null : $fallback;
         $this->fallbackLocaleIdentifier = $fallbackLocaleIdentifier;
     }

--- a/Resources/Private/Fusion/Backend/Views/Show.fusion
+++ b/Resources/Private/Fusion/Backend/Views/Show.fusion
@@ -36,7 +36,7 @@ prototype(Sitegeist.CsvPO:Views.Show) < prototype(Neos.Fusion:Component) {
                                 </div>
                             </td>
                             <td>
-                                <Neos.Fusion:Link.Action  @if={translationInLocale.override}
+                                <Neos.Fusion:Link.Action  @if={translationInLocale.override != null}
                                     href.action="updateOverride"
                                     href.arguments.sourceIdentifier={source.identifier}
                                     href.arguments.labelIdentifier={translationIdentifier}
@@ -45,7 +45,7 @@ prototype(Sitegeist.CsvPO:Views.Show) < prototype(Neos.Fusion:Component) {
                                     <i class="fas fa-pencil-alt icon-white"></i>
                                 </Neos.Fusion:Link.Action>
                                 <Neos.Fusion:Link.Action
-                                    @if={!translationInLocale.override}
+                                    @if={translationInLocale.override == null}
                                     href.action="newOverride"
                                     href.arguments.sourceIdentifier={source.identifier}
                                     href.arguments.labelIdentifier={translationIdentifier}


### PR DESCRIPTION
By updating a translation in backend module, it is allowed to set empty string as translation. As a result we have a record in sitegeist_csvpo_domain_translationoverride with empty string as the translation. On the other hand when it comes to overrides the code sees empty strings as null and gives the option to "add" a new override with the same keys which are already in the table, which causes a doctrine dbal exception. 
We have two options
1- Do not allow empty strings in update action.
2- Reflect the exact state of the override table and update records.

In this branch the second option is implemented.